### PR TITLE
status update workflow for verify

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -36,8 +36,8 @@ class Institution < ApplicationRecord
 
   before_save do
     # setting up the configs
-    self.max_line_edits = min_lines_for_consensus + 1
+    self.max_line_edits = min_lines_for_consensus
     self.min_lines_for_consensus_no_edits = min_lines_for_consensus
-    self.min_percent_consensus = min_lines_for_consensus.to_f / max_line_edits.to_f
+    self.min_percent_consensus = min_lines_for_consensus.to_f / (max_line_edits + 1).to_f
   end
 end

--- a/spec/factories/transcript_edit.rb
+++ b/spec/factories/transcript_edit.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :transcript_edit do
     transcript
     transcript_line
-    user
+    user_id 1
     text { Faker::Lorem.sentence }
     session_id { Faker::Crypto.md5 }
   end

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Institution, type: :model do
 
   # validations
   it { is_expected.to validate_presence_of(:name) }
-  it { is_expected.to validate_numericality_of(:max_line_edits) }
   it { is_expected.to validate_uniqueness_of(:name) }
   it { is_expected.to allow_value("correct-value").for(:slug) }
   it { is_expected.not_to allow_value("value with space").for(:slug) }
@@ -25,17 +24,23 @@ RSpec.describe Institution, type: :model do
   end
 
   context "when saving a record" do
+    subject(:save) do
+      institution.min_lines_for_consensus = 4
+      institution.save
+      institution.reload
+    end
+
     let(:institution) do
-      FactoryBot.create(:institution,
-                        max_line_edits: 4,
-                        min_lines_for_consensus: 0,
-                        min_lines_for_consensus_no_edits: 0)
+      FactoryBot.build(:institution,
+                       max_line_edits: 0,
+                       min_lines_for_consensus: 0,
+                       min_lines_for_consensus_no_edits: 0)
     end
 
     it "updates other configs" do
-      ins = Institution.find(institution.id)
-      expect(ins.min_lines_for_consensus).to eq(4)
-      expect(ins.min_lines_for_consensus_no_edits).to eq(4)
+      save
+      expect(institution.max_line_edits).to eq(4)
+      expect(institution.min_lines_for_consensus_no_edits).to eq(4)
     end
   end
 end

--- a/spec/models/transcript_line_spec.rb
+++ b/spec/models/transcript_line_spec.rb
@@ -1,0 +1,91 @@
+RSpec.describe TranscriptLine, type: :model do
+  describe "#recalculate" do
+    let(:min_lines_for_consensus) { 2 }
+    let(:institution) do
+      FactoryBot.create :institution,
+                        min_lines_for_consensus: min_lines_for_consensus
+    end
+    let(:original_text) { "original text" }
+    let(:collection) { FactoryBot.create :collection, institution: institution }
+    let!(:transcript) { FactoryBot.create :transcript, collection: collection }
+    let(:transcript_line) do
+      FactoryBot.create :transcript_line,
+                        transcript: transcript,
+                        original_text: original_text
+    end
+    let(:transcript_edit) do
+      FactoryBot.create :transcript_edit,
+                        transcript: transcript,
+                        transcript_line: transcript_line
+    end
+    let(:project) { Project.getActive(collection.id) }
+
+    let!(:statues) do
+      # rubocop:disable Metrics/LineLength
+      [
+        { name: "initialized", progress: 0, description: "Line contains unedited computer-generated text" },
+        { name: "editing", progress: 25, description: "Line has been edited by others" },
+        { name: "reviewing", progress: 50, description: "Line is being reviewed" },
+        { name: "completed", progress: 100, description: "Line has been completed" },
+        { name: "flagged", progress: 150, description: "Line has been marked as incorrect or problematic" },
+        { name: "archived", progress: 200, description: "Line has been archived" },
+      ].each do |item|
+        TranscriptLineStatus.create(name: item[:name], progress: item[:progress], description: item["description"])
+      end
+      # rubocop:enable Metrics/LineLength
+    end
+
+    # rubocop:disable RSpec/ExampleLength: Example has too many lines
+    context "when verifying with 2 min_lines_for_consensus" do
+      let!(:min_lines_for_consensus) { 2 }
+
+      it "third selection should make the line as completed" do
+        create_edit_and_recalculate("first")
+        expect(transcript_line.transcript_line_status.name).to eq("editing")
+
+        create_edit_and_recalculate("second")
+        expect(transcript_line.transcript_line_status.name).to eq("reviewing")
+
+        create_edit_and_recalculate("first")
+        expect(transcript_line.transcript_line_status.name).to eq("completed")
+      end
+    end
+
+    context "when verifying with 4 min_lines_for_consensus" do
+      let!(:min_lines_for_consensus) { 4 }
+
+      it "fifth selection should make the line as completed" do
+        create_edit_and_recalculate("first")
+        create_edit_and_recalculate("first")
+        create_edit_and_recalculate("first")
+        expect(transcript_line.transcript_line_status.name).to eq("editing")
+
+        create_edit_and_recalculate("second")
+        expect(transcript_line.transcript_line_status.name).to eq("reviewing")
+
+        create_edit_and_recalculate("first")
+        expect(transcript_line.transcript_line_status.name).to eq("completed")
+      end
+    end
+    # rubocop:enable RSpec/ExampleLength: Example has too many lines
+  end
+
+  private
+
+  def create_edit_and_recalculate(text)
+    create_edit(text)
+    re_calculate
+  end
+
+  def create_edit(text)
+    FactoryBot.create :transcript_edit,
+                      transcript: transcript,
+                      transcript_line: transcript_line,
+                      text: text
+  end
+
+  def re_calculate
+    transcript_line.recalculate(nil, project)
+    transcript_line.reload
+  end
+end

--- a/test/models/transcript_line_test.rb
+++ b/test/models/transcript_line_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-class TranscriptLineTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end


### PR DESCRIPTION
testing the workflow of `verifying` a transcript line item

Eg. If the `min_lines_for_consensus` set to 2

- user 1 edit as `A` (same line)
- user 2 edit as `B` (same line)
- user 3 get to `verify` by picking either A or B

