### PR TITLE
making flay_type optional

### DIFF
--- a/app/assets/stylesheets/project.css
+++ b/app/assets/stylesheets/project.css
@@ -2680,6 +2680,9 @@ body {
 #transcript-line-flag .modal {
     z-index: 1000;
 }
+#transcript-line-flag .modal.active {
+  display: block;
+}
 #transcript-line-flag .modal .modal-inner {
     top: 80px;
 }

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -1,6 +1,6 @@
 class Flag < ApplicationRecord
   belongs_to :transcript_line
-  belongs_to :flag_type
+  belongs_to :flag_type, optional: true
 
   def self.getByLine(transcript_line_id)
     Flag

--- a/spec/factories/flag.rb
+++ b/spec/factories/flag.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :flag do
+    transcript_line
+    flag_type
+  end
+end

--- a/spec/factories/flag_type.rb
+++ b/spec/factories/flag_type.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :flag_type do
+    name { Faker::Color.color_name }
+    label { Faker::Lorem.word }
+    description { Faker::Lorem.word }
+    category "error"
+  end
+end

--- a/spec/models/flag_spec.rb
+++ b/spec/models/flag_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Flag, type: :model do
+  describe "saving flag" do
+    let(:flag) { FactoryBot.build(:flag, flag_type_id: 0) }
+
+    context "without a flag type" do
+      # custom text
+      it "saves flag type" do
+        expect(flag.save).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
1 - Fixing css on flag popup

<img width="850" alt="screen shot 2018-08-08 at 10 52 25 pm" src="https://user-images.githubusercontent.com/98407/43838096-c42a68de-9b5d-11e8-9499-5080193b0046.png">


2 - Making the flag_type relation (belongs_to) optional. This requires when receiving custom text