### PR TITLE
link checkbox fix, document page rename

### DIFF
--- a/app/assets/stylesheets/admin_cms.scss
+++ b/app/assets/stylesheets/admin_cms.scss
@@ -4,3 +4,8 @@
   left: 33%;
   top: -30%;
 }
+#sn-checkbox-open-in-new-window {
+  position: inherit;
+  z-index: 1;
+  opacity: 1;
+}

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -9,7 +9,7 @@ module AdminHelper
       OpenStruct.new(path: admin_pages_path, icon: "file", text: "Pages", type: 4),
       OpenStruct.new(path: admin_themes_path, icon: "paint-brush", text: "Themes", type: 4),
       OpenStruct.new(path: edit_admin_app_config_path(@app_config.id), icon: "cog", text: "Site Config", type: 4),
-      OpenStruct.new(path: "/page/documentation", icon: "question-circle", text: "Documentation", type: 2),
+      OpenStruct.new(path: "/page/user_guide", icon: "question-circle", text: "User Guide", type: 2),
     ]
     list.reject { |i| i.type > user_type }
   end

--- a/app/views/admin/pages/_form.html.erb
+++ b/app/views/admin/pages/_form.html.erb
@@ -25,7 +25,7 @@
   </div>
   <div class="form-check">
     <%= form.check_box :admin_access, class: 'form-check-input' %>
-    <%= form.label 'Restrict access for normal users', for: 'page_admin_access', class: 'form-check-label' %>
+    <%= form.label 'Restrict access for public users', for: 'page_admin_access', class: 'form-check-label' %>
   </div>
 
   <br />

--- a/db/data/20180905045354_change_documentation_page_to_user_guide.rb
+++ b/db/data/20180905045354_change_documentation_page_to_user_guide.rb
@@ -1,0 +1,12 @@
+class ChangeDocumentationPageToUserGuide < SeedMigration::Migration
+  def up
+    page = Page.where(page_type: "documentation").first
+    PublicPage.where(page_id: page.id).delete_all
+    page.destroy
+    Page.create(content: "User Guide", page_type: "user_guide", published: true)
+  end
+
+  def down
+    Page.where(page_type: "user_guide").delete_all
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,4 +13,4 @@
 ActiveRecord::Base.transaction do
 end
 
-SeedMigration::Migrator.bootstrap(20180905003543)
+SeedMigration::Migrator.bootstrap(20180905045354)


### PR DESCRIPTION
- showing the link type checkbox

![screen shot 2018-09-05 at 3 21 58 pm](https://user-images.githubusercontent.com/98407/45072704-88ade380-b11f-11e8-812b-ce2c3fc340a9.png)

- rename the `Document` page to `User Guide`