### PR TITLE
adding delete option to admin pages

### DIFF
--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -38,8 +38,8 @@ class Admin::PagesController < AdminController
   end
 
   def destroy
-    # institution.destroy
-    # redirect_to admin_institutions_path
+    @page.destroy
+    redirect_to admin_pages_path
   end
 
   def upload

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -2,7 +2,6 @@ class Page < ApplicationRecord
   has_one :public_page, dependent: :destroy
 
   validates :page_type, presence: true
-  validates :content, uniqueness: true
   validates :page_type, uniqueness: true
   validates :page_type,
             format: { with: /\A^[a-zA-Z0-9_-]*$\z/ },

--- a/app/views/admin/pages/index.html.erb
+++ b/app/views/admin/pages/index.html.erb
@@ -5,7 +5,7 @@
   <thead class="thead-dark">
     <tr>
       <th scope="col">Type</th>
-      <th colspan="2" scope="col"></th>
+      <th colspan="3" scope="col"></th>
     </tr>
   </thead>
 
@@ -24,6 +24,12 @@
             <%= fa_icon "edit" %>
           <% end %>
         </td>
+        <td>
+          <%= button_to admin_page_path(page), data: {confirm: 'Are you sure you want to delete this page? This action cannot be undone.'}, method: :delete do %>
+            <%= fa_icon "trash" %>
+          <% end %>
+        </td>
+
       </tr>
     <% end %>
   </tbody>

--- a/spec/factories/public_pages.rb
+++ b/spec/factories/public_pages.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :public_page do
-    page_id 1
+    page
     content "MyString"
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Page, type: :model do
   # validations
   it { is_expected.to validate_presence_of(:page_type) }
   it { is_expected.to validate_uniqueness_of(:page_type) }
-  it { is_expected.to validate_uniqueness_of(:content) }
 
   # page type
   it { is_expected.to validate_length_of(:page_type).is_at_most(50) }
@@ -60,6 +59,17 @@ RSpec.describe Page, type: :model do
           page.save
         end.to change { PublicPage.count }.by(1)
       end
+    end
+  end
+
+  context "with destroy" do
+    let(:public_page) { create :public_page }
+    let!(:page) { public_page.page }
+
+    it "also deletes the public page" do
+      expect do
+        page.destroy
+      end.to change { PublicPage.count }.by(-1)
     end
   end
   # rubocop:enable RSpec/ExpectChange


### PR DESCRIPTION
- adding delete option to the admin pages
- removed the `uniqueness` validation from Pages