### PR TITLE
makes the search work on enter

### DIFF
--- a/app/assets/javascripts/home.js
+++ b/app/assets/javascripts/home.js
@@ -76,8 +76,15 @@ $(document).ready(function(){
   })
 
   $("#searchText").on('keyup',function(e){
+    // 8 = backspace
     if (($(this).val() == "") && (e.keyCode == 8)){
       searchText = "";
+      loadTranscripts()
+    }
+    // 13 = enter
+    if (e.keyCode == 13) {
+      searchText = $('#searchText').val()
+      event.preventDefault();
       loadTranscripts()
     }
   })


### PR DESCRIPTION
Currently the search form only works when you click the search button. This makes it so you can also search by pressing enter after you type your query.


<img width="621" alt="Screen Shot 2019-06-13 at 11 45 14 am" src="https://user-images.githubusercontent.com/5127756/59397692-e3701c00-8dd0-11e9-9364-2d9b0e128bac.png">
