### PR TITLE
Update/transcript responsive styling

### DIFF
--- a/app/assets/stylesheets/components/editor/_lines.scss
+++ b/app/assets/stylesheets/components/editor/_lines.scss
@@ -9,10 +9,11 @@ $transcript-line-options-width: 80px; // 80px
 $transcript-line-options-reviewing-width: 80px;
 
 .transcript-lines {
-  margin: 0 0 400px 0;
   border-top: 10px solid $coolgray-color;
   border-bottom: 10px solid $coolgray-color;
-
+  @include desktop {
+    margin: 0 0 400px 0;
+  }
   .line {
     position: relative;
     width: 100%;
@@ -244,7 +245,7 @@ $transcript-line-options-reviewing-width: 80px;
         &:hover, &:focus, &:active {
           background: darken($editor-button-color, 10%);
           color: $white;
-          text-decoration: none; 
+          text-decoration: none;
         }
       }
     }

--- a/app/assets/stylesheets/components/editor/_show.scss
+++ b/app/assets/stylesheets/components/editor/_show.scss
@@ -5,13 +5,8 @@ $header-image-width: 100%;
 $transcript-content-width: 800px;
 
 .transcript-header {
-  width: auto;
   position: relative;
   background: lighten($coolgray-color, 25%);
-  margin: (-$header-nav-height - 21px) 0 20px;
-  padding-bottom: 10px;
-  min-height: 240px;
-  overflow-x: hidden;
   @include box-sizing();
 
   &:after {
@@ -40,11 +35,19 @@ $transcript-content-width: 800px;
   .metadata {
     position: relative;
     margin: 0 auto;
-    margin-top: 58px;
+    padding-top: 58px;
     max-width: $transcript-content-width;
     z-index: 5;
+    @include mobile {
+      padding: 15px;
+    }
     h1 {
       margin-bottom: 0;
+      @include mobile {
+        font-size: 2rem;
+        line-height: 1.3;
+        margin-bottom: 0.5em;
+      }
       small {
         color: darken($coolgray-dark-color, 10%);
 
@@ -67,7 +70,7 @@ $transcript-content-width: 800px;
     }
     a {
       color: $cyan;
-      font-size: 1rem;
+      font-size: inherit;
     }
     .duration, .speakers, .original-link, .download-link {
       font-style: italic;
@@ -105,11 +108,12 @@ $transcript-content-width: 800px;
       }
     }
     .download-link {
+      font-size: 1rem;
       @include mobile {
         display: none;
       }
       a {
-        font-size: 1rem;
+        font-size: inherit;
         &:after {
           @include icon("\f019");
           font-style: normal;
@@ -121,7 +125,9 @@ $transcript-content-width: 800px;
     }
 
     .social {
-      padding-bottom: 1.5em;
+      @include desktop {
+        padding-bottom: 1.5em;
+      }
 
       // Align Facebook button nicely.
       > * {
@@ -142,15 +148,19 @@ $transcript-content-width: 800px;
   }
 
   .status-wrapper {
-    position: absolute;
-    right: 20px;
-    bottom: 20px;
-    width: 300px;
-    height: auto;
     border: 1px solid $coolgray-color;
     background: $white;
     @include box-sizing();
-
+    @include desktop {
+      position: absolute;
+      right: 20px;
+      bottom: 20px;
+      width: 300px;
+      height: auto;
+    }
+    @include mobile {
+      margin: 15px;
+    }
     .status-contributors {
       padding: 5px;
       font-size: 0.9em;

--- a/app/assets/stylesheets/components/editor/_show.scss
+++ b/app/assets/stylesheets/components/editor/_show.scss
@@ -105,6 +105,9 @@ $transcript-content-width: 800px;
       }
     }
     .download-link {
+      @include mobile {
+        display: none;
+      }
       a {
         font-size: 1rem;
         &:after {

--- a/app/assets/stylesheets/components/editor/_show.scss
+++ b/app/assets/stylesheets/components/editor/_show.scss
@@ -170,10 +170,16 @@ $transcript-content-width: 800px;
 }
 
 .transcript-page {
-  max-width: $transcript-content-width;
-  margin: 0 auto 40px;
-  padding: 0 20px;
-  @include box-sizing();
+  height: 0;
+  visibility: hidden;
+  @include desktop {
+    max-width: $transcript-content-width;
+    height: auto;
+    visibility: visible;
+    margin: 0 auto 40px;
+    padding: 0 20px;
+    @include box-sizing();
+  }
 
   h1, h2 {
     margin: 0;
@@ -191,6 +197,17 @@ $transcript-content-width: 800px;
   .transcript_edit\.md.page {
     ul li {
       list-style: disc;
+    }
+  }
+
+  .play-all {
+    @include mobile {
+      position: fixed;
+      bottom: 5px;
+      left: calc(50% - 76px);
+      visibility: visible;
+      z-index: 50;
+      margin: 0;
     }
   }
 

--- a/app/assets/stylesheets/components/editor/_toolbar.scss
+++ b/app/assets/stylesheets/components/editor/_toolbar.scss
@@ -12,7 +12,9 @@ $toolbar-notifications-width: 0px; // 200px
   min-height: $secondary-header-nav-height;
   line-height: $secondary-header-nav-height;
   @include clearfix();
-
+  @include mobile {
+    display: none;
+  }
   .controls {
     width: auto;
     max-width: 1200px;

--- a/app/assets/stylesheets/components/footer.scss
+++ b/app/assets/stylesheets/components/footer.scss
@@ -35,6 +35,10 @@
       color: $sub-footer-foreground;
       font-size: rem-calc(12);
       text-transform: uppercase;
+      margin: 0;
+      @include mobile {
+        font-size: rem-calc(10);
+      }
     }
   }
 }


### PR DESCRIPTION
Updating the transcript page mobile view:
 - Hiding the download link
 - Making the title smaller
 - Updating the whitespace
 - Making sure the contributors box doesn't overlap
 - Hiding the instructions
 - Hiding the bottom navigation
 - Making a sticky play button

**Current**
<img width="364" alt="Screen Shot 2019-06-13 at 4 31 21 pm" src="https://user-images.githubusercontent.com/5127756/59409053-b8012780-8df8-11e9-881a-0e1c3e06933d.png">

**New**
<img width="359" alt="Screen Shot 2019-06-13 at 4 24 48 pm" src="https://user-images.githubusercontent.com/5127756/59408884-550f9080-8df8-11e9-9991-eb8de3df0310.png">
