### PR TITLE
collapsible feature added to user dashboard

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -25,6 +25,7 @@
 //= require mobile_transcripts
 //= require jquery.Jcrop.min
 //= require select2
+//= require dashboard
 
 // Convert legacy thumbnails.
 (function () {

--- a/app/assets/javascripts/dashboard.coffee
+++ b/app/assets/javascripts/dashboard.coffee
@@ -1,3 +1,15 @@
 # Place all the behaviors and hooks related to the matching controller here.
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
+
+$(document).on 'ready', ->
+  $('.toggle-link').on 'click', (e) ->
+    e.preventDefault()
+    link = $(this)
+    transcriptId = link.attr('id')
+    collapsible = $('#collapsed-' + transcriptId)
+    collapsible.toggle()
+    text = if collapsible.is(':hidden') then 'Expand' else 'Collapse'
+    link.text text
+    return
+  return

--- a/app/assets/stylesheets/components/dashboard.scss
+++ b/app/assets/stylesheets/components/dashboard.scss
@@ -51,3 +51,8 @@
 
 }
 
+.text-center { text-align: center; }
+
+.collapsed {
+  display: none;
+}

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -25,4 +25,8 @@ module DashboardHelper
   def time_in_seconds(time)
     display_time(time.to_i * Transcript.seconds_per_line)
   end
+
+  def edits_min_display
+    7 # assign to environment variable maybe?, so there will be no code change if client decides to change the minimum display
+  end
 end

--- a/app/views/dashboard/_transcript_edits.html.erb
+++ b/app/views/dashboard/_transcript_edits.html.erb
@@ -13,7 +13,7 @@
   </div>
   <div class="flex-container__edits_div">
     <div class="transcript-edits">
-       <% edits.first(7).each do |e| %>
+       <% edits.first(edits_min_display).each do |e| %>
          <div class="transcript-edit">
            <%= e.text %>
          </div>
@@ -21,7 +21,7 @@
     </div>
     <% if edits.length > edits_min_display %>
       <div class="transcript-edits collapsed" id="collapsed-<%= transcript.id %>">
-        <% edits[7..-1].each do |e| %>
+        <% edits[edits_min_display..-1].each do |e| %>
             <div class="transcript-edit">
               <%= e.text %>
             </div>

--- a/app/views/dashboard/_transcript_edits.html.erb
+++ b/app/views/dashboard/_transcript_edits.html.erb
@@ -13,12 +13,21 @@
   </div>
   <div class="flex-container__edits_div">
     <div class="transcript-edits">
-       <% edits.each do |e| %>
+       <% edits.first(7).each do |e| %>
          <div class="transcript-edit">
            <%= e.text %>
          </div>
        <% end %>
-     </div>
+    </div>
+    <% if edits.length > edits_min_display %>
+      <div class="transcript-edits collapsed" id="collapsed-<%= transcript.id %>">
+        <% edits[7..-1].each do |e| %>
+            <div class="transcript-edit">
+              <%= e.text %>
+            </div>
+        <% end %>
+      </div>
+    <% end %>
   </div>
   <div class="flex-container__stats_div">
     <div class="stat-details">
@@ -38,8 +47,11 @@
         ~<%= time_in_seconds(edits.length)  %> of audio
       </h4>
     </div>
+    <% if edits.length > edits_min_display %>
+      <div class="text-center">
+        <%= link_to 'Expand', '#', class: "toggle-link", id: transcript.id %>
+      </div>
+    <% end %>
   </div>
 </div>
 <% end  %>
-
-


### PR DESCRIPTION
## Ticket

https://reinteractive.zendesk.com/agent/tickets/57563

## Description

- In user dashboard, change individual item listing to be collapsed by default rather than showing every edited line of the transcript. Show a maximum of 7 lines for each item and a “click to expand” option if there are more than 7 lines.

## Screenshots
![Screen Shot 2021-03-25 at 4 40 28 PM (2)](https://user-images.githubusercontent.com/319842/112444443-fe830480-8d88-11eb-88a2-79cf3f85d580.png)

![Screen Shot 2021-03-25 at 4 40 40 PM (2)](https://user-images.githubusercontent.com/319842/112444462-05117c00-8d89-11eb-81b0-1f34ee18116f.png)
