### PR TITLE
item image caption from textbox to html editor

### DIFF
--- a/app/views/admin/cms/transcripts/_form.html.erb
+++ b/app/views/admin/cms/transcripts/_form.html.erb
@@ -90,7 +90,7 @@
 
       <div class="form-group">
         <%= f.label :image_caption %>
-        <%= f.text_field :image_caption, class: "form-control" %>
+        <%= f.text_area :image_caption, class: "form-control", "data-provider": :summernote %>
       </div>
 
       <div class="form-group">


### PR DESCRIPTION
## Ticket

https://reinteractive.zendesk.com/agent/tickets/57938

## Description

Change the following text fields to HTML editor field (WYSIWYG) and render HTML on correlating page:

Item page
- [x] Description
- [x] Image caption

Collection page
- [x] Description

## Screenshots

### Collection Description html editor
![Screen Shot 2021-03-26 at 10 28 39 AM (2)](https://user-images.githubusercontent.com/319842/112570041-43a64580-8e20-11eb-812e-a639d90de704.png)

![Screen Shot 2021-03-26 at 10 28 47 AM (2)](https://user-images.githubusercontent.com/319842/112570079-5751ac00-8e20-11eb-8795-5704b6d705c3.png)

### Item image caption html editor
![Screen Shot 2021-03-26 at 10 28 52 AM (2)](https://user-images.githubusercontent.com/319842/112570118-69334f00-8e20-11eb-98dc-acb204a3b687.png)

![Screen Shot 2021-03-26 at 10 28 58 AM (2)](https://user-images.githubusercontent.com/319842/112570165-80723c80-8e20-11eb-8eba-561e8881b454.png)
