### PR TITLE
convert admin users collapse into tabs

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -30,7 +30,7 @@ class Admin::UsersController < AdminController
 
   def load_collections
     @users = policy_scope(User).only_public_users.getAll.decorate
-    @staff = policy_scope(User).only_staff_users.getAll.decorate
+    @staff = policy_scope(User).only_staff_users.orderByInstitution.decorate
     @user_roles = policy_scope(UserRole).getAll
     @institutions = policy_scope(Institution).all
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,6 +80,10 @@ class User < ApplicationRecord
     User.order("lines_edited DESC").limit(1000)
   end
 
+  def self.orderByInstitution
+    self.includes(:institution).order("institutions.name ASC NULLS FIRST").limit(1000)
+  end
+
   def self.getStatsByDay
     Rails.cache.fetch("#{ENV['PROJECT_ID']}/users/stats", expires_in: 10.minutes) do
       User

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,33 +1,22 @@
 <%= render partial: 'layouts/admin_side_pane' %>
-<div class="accordion" id="accordionUser">
-  <div class="card">
-    <div class="card-header" id="headingOne">
-      <h5 class="mb-0">
-        <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
-          <h3>Top Users</h3>
-        </button>
-      </h5>
-    </div>
 
-    <div id="collapseOne" class="collapse show" aria-labelledby="headingOne" data-parent="#accordionUser">
-      <div class="card-body">
-        <%= render "users", users: @users, user_roles: @user_roles, institutions: @institutions, can_delete: true %>
-      </div>
-    </div>
+<ul class="nav nav-tabs" id="users-tab" role="tablist">
+  <li class="nav-item">
+    <a class="nav-link active" id="registered-tab" data-toggle="tab" href="#registered" role="tab" aria-controls="registered" aria-selected="true">
+      Registered Users
+    </a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" id="administrative-tab" data-toggle="tab" href="#administrative" role="tab" aria-controls="administrative" aria-selected="false">
+      Administrative Users
+    </a>
+  </li>
+</ul>
+<div class="tab-content" id="users-content">
+  <div class="tab-pane fade show active" id="registered" role="tabpanel" aria-labelledby="registered-tab">
+    <%= render "users", users: @users, user_roles: @user_roles, institutions: @institutions, can_delete: true %>
   </div>
-  <div class="card">
-    <div class="card-header" id="headingTwo">
-      <h5 class="mb-0">
-        <button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
-         <h3>Administrative Users</h3>
-        </button>
-      </h5>
-    </div>
-    <div id="collapseTwo" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionUser">
-      <div class="card-body">
-        <%= render "users", users: @staff, user_roles: @user_roles, institutions: @institutions, can_delete: false %>
-      </div>
-    </div>
+  <div class="tab-pane fade" id="administrative" role="tabpanel" aria-labelledby="administrative-tab">
+    <%= render "users", users: @staff, user_roles: @user_roles, institutions: @institutions, can_delete: false %>
   </div>
 </div>
-

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -26,4 +26,26 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  # class methods
+  context "class methods" do
+    let(:registred_user_role) { create :user_role, id: 2 }
+
+    let(:institution_1) { create :institution, name: "Australian War Memorial" }
+    let(:institution_2) { create :institution, name: "State Library of Queensland" }
+    let(:institution_3) { create :institution, name: "Wollongong City Libraries" }
+
+    let!(:user_1) { create :user, user_role: registred_user_role }
+    let!(:user_2) { create :user, user_role: registred_user_role, institution: institution_1 }
+    let!(:user_3) { create :user, user_role: registred_user_role, institution: institution_2 }
+    let!(:user_4) { create :user, user_role: registred_user_role, institution: institution_3 }
+
+    describe "#orderByInstitution" do
+      it "arrange users on ascending order based on institution name" do
+        expect(User.orderByInstitution).to eq [user_1, user_2, user_3, user_4]
+        expect(User.orderByInstitution.first.institution).to eq nil
+        expect(User.orderByInstitution.last.institution.name).to eq institution_3.name
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Ticket

- https://reinteractive.zendesk.com/agent/tickets/57982

## Description

- Improve layout of list of registered and administrative users

## Screenshots

### Registered Users
![Screen Shot 2021-03-30 at 4 01 02 PM (2)](https://user-images.githubusercontent.com/319842/112955243-d07b3700-9171-11eb-826a-2a9f15710edf.png)

### Administrative Users
![Screen Shot 2021-03-30 at 4 01 10 PM (2)](https://user-images.githubusercontent.com/319842/112955361-ebe64200-9171-11eb-9fe2-de79f095486e.png)

![Screen Shot 2021-03-30 at 4 01 20 PM (2)](https://user-images.githubusercontent.com/319842/112955382-f1438c80-9171-11eb-93c4-52c7e6bbc5d5.png)
