### PR TITLE
changes on admin users tab font

### DIFF
--- a/app/assets/stylesheets/admin_cms.scss
+++ b/app/assets/stylesheets/admin_cms.scss
@@ -59,3 +59,8 @@
 .alert-primary {
   padding: 5px 10px;
 }
+
+#users-tab a {
+  font-weight: bold;
+  font-size: 20px;
+}


### PR DESCRIPTION
## Ticket

- https://reinteractive.zendesk.com/agent/tickets/57982

## Description

- Increase admin users tab font

## Screenshots

<img width="1280" alt="Screen Shot 2021-04-06 at 9 02 03 AM" src="https://user-images.githubusercontent.com/319842/113644433-512cbc80-96b7-11eb-90e5-41d2511b1809.png">
